### PR TITLE
Add support for episode start in Invoke-DvdProcessing

### DIFF
--- a/Modules/Media/Private/Copy-FileWithMetadata.ps1
+++ b/Modules/Media/Private/Copy-FileWithMetadata.ps1
@@ -51,6 +51,9 @@ function Copy-FileWithMetadata {
         [Parameter(Mandatory)]
         [ValidateNotNull()]
         [object[]]$Episodes,
+        [Parameter()]
+        [ValidateRange(1, 1000)]
+        [int]$EpisodeStart = 1,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$Destination,
@@ -63,7 +66,7 @@ function Copy-FileWithMetadata {
     )
     begin {
         $allFiles = @()
-        Write-Message "Initializing file copying with metadata and pipeline support" -Type Verbose
+        Write-Message 'Initializing file copying with metadata and pipeline support' -Type Verbose
         Write-Message "Destination: $Destination" -Type Verbose
         Write-Message "Title: $Title" -Type Verbose
         Write-Message "Season: $Season" -Type Verbose
@@ -75,33 +78,39 @@ function Copy-FileWithMetadata {
         }
     }
     end {
-        return Invoke-WithErrorHandling -OperationName "File copying with metadata" -DefaultReturnValue @() -ErrorEmoji "🎬" -ScriptBlock {
+        return Invoke-WithErrorHandling -OperationName 'File copying with metadata' -DefaultReturnValue @() -ErrorEmoji "🎬" -ScriptBlock {
             # Check if we have enough files for all episodes
             if ($allFiles.Count -eq 0) {
                 Write-Message '🚫 No files provided for copying.' -Type Error
                 return @()
             }
-            if ($allFiles.Count -lt $Episodes.Count) {
-                Write-Message "⚠️ Found $($allFiles.Count) files but need $($Episodes.Count) episodes. Some episodes may be missing." -Type Warning
-            }
+
             # Copy files with TVDb metadata
-            Write-Message "🎬 Copying $($allFiles.Count) files to destination"
+            Write-Message "🎬 Copying $($allFiles.Count) files to destination" -Type Processing
             $copiedFiles = @()
-            for ($i = 0; $i -lt [Math]::Min($Episodes.Count, $allFiles.Count); $i++) {
-                $episode = $Episodes[$i]
+            $episodeIndex = $episodeStart - 1
+            $maxCount = [Math]::Min($Episodes.Count - $EpisodeStart, $allFiles.Count)
+            for ($i = 0; $i -lt $maxCount; $i++) {
+                $episode = $Episodes[$episodeIndex++]
                 $file = $allFiles[$i]
+                Write-Message "Episode: '$($episode.Title)' ($($file.Name))" -Type Processing
+
                 # Create episode-based filename with TVDb metadata
-                $episodeNumber = $episode.Number
-                $episodeTitle = $episode.Name
+                $episodeNumber = $episode.EpisodeNumber
+                $episodeTitle = $episode.Title
                 $tvdbId = $episode.Id
+
                 # Clean episode title for filename
                 $cleanTitle = $episodeTitle -replace '[<>:"/\\|?*]', ''
                 $cleanTitle = $cleanTitle -replace '\s+', ' '
                 $cleanTitle = $cleanTitle.Trim()
+
                 # Create new filename with metadata
-                $newFileName = "$Title {tvdb $tvdbId} - s{0:D2}e{1:D2} - $cleanTitle.mkv" -f $Season, $episodeNumber
+                $seasonEpisodeString = 's{0:D2}e{1:D2}' -f $Season, $episodeNumber
+                $newFileName = "$Title {tvdb $tvdbId} - $seasonEpisodeString.mkv"
                 $destinationPath = Get-Path -Path $Destination, $newFileName -PathType Absolute
                 Write-Message "📁 Copying: $($file.Name) -> $newFileName" -Type Verbose
+
                 # Check if destination file already exists with same size
                 if (Test-Path $destinationPath) {
                     $existingFile = Get-Item $destinationPath
@@ -114,14 +123,10 @@ function Copy-FileWithMetadata {
                         Write-Message "⚠️ File exists but different size, will overwrite: $newFileName" -Type Warning
                     }
                 }
+
                 # Copy file with WhatIf/Confirm support
-                $copyParams = @{
-                    Path = $file.FullName
-                    Destination = $destinationPath
-                    Force = $true
-                }
-                if ($PSCmdlet.ShouldProcess($destinationPath, "Copy file")) {
-                    Copy-Item @copyParams
+                if ($PSCmdlet.ShouldProcess($destinationPath, 'Copy file')) {
+                    Copy-Item -Path $file.FullName -Destination $destinationPath -Force
                     if (Test-Path $destinationPath) {
                         Write-Message "✅ Copied: $newFileName" -Type Success
                         $copiedFiles += $destinationPath
@@ -135,7 +140,7 @@ function Copy-FileWithMetadata {
                     $copiedFiles += $destinationPath
                 }
             }
-            Write-Message "🎯 Total files copied: $($copiedFiles.Count)" -Type Verbose
+            Write-Message "🎯 Total files copied: $($copiedFiles.Count)" -Type Success
             return $copiedFiles
         }
     }

--- a/Modules/Media/Private/Get-FilteredVideoFiles.ps1
+++ b/Modules/Media/Private/Get-FilteredVideoFiles.ps1
@@ -65,7 +65,7 @@ function Get-FilteredVideoFiles {
     }
     end {
         return Invoke-WithErrorHandling -OperationName 'File Filtering' -DefaultReturnValue @() -ErrorEmoji '🎬' -ScriptBlock {
-            Write-Message "Get-FilteredVideoFilesProcessing directories: $($allDirectories -join ', ')" -Type Info
+            Write-Message "Processing directories: $($allDirectories -join ', ')" -Type Info
             # Resolve all directories to absolute paths
             $directories = @()
             Get-Item -Path $allDirectories | ForEach-Object {

--- a/Modules/Media/Public/Export-Chapter.ps1
+++ b/Modules/Media/Public/Export-Chapter.ps1
@@ -61,10 +61,10 @@ function Export-Chapter {
         Write-Message "ffmpeg command arguments: $($ffmpegArgs -join ' ')" -Type Verbose
         if ($PSCmdlet.ShouldProcess("$InputFile ➡️ $OutputFile", 'Extract chapter')) {
             Write-Message 'Executing ffmpeg chapter extraction' -Type Verbose
-            $ffmpegOutput = Invoke-FFmpeg -Arguments $ffmpegArgs            
-            Write-Message "ffmpeg completed with exit code: $($ffmpegOutput.ExitCode)" -Type Success
-            Write-Message "ffmpeg output $($ffmpegOutput.Output?.Length)" -Type Processing
-            Write-Message "ffmpeg output $($ffmpegOutput.Error?.Length)" -Type Processing
+            $ffmpegOutput = Invoke-FFmpeg -Arguments $ffmpegArgs
+            Write-Message "ffmpeg completed with exit code: $($ffmpegOutput.ExitCode)" -Type Verbose
+            Write-Message "ffmpeg output $($ffmpegOutput.Output?.Length)" -Type Info
+            Write-Message "ffmpeg error $($ffmpegOutput.Error?.Length)" -Type Info
             if ($ffmpegOutput.ExitCode -ne 0) {
                 Write-Message 'ffmpeg chapter extraction failed' -Type Verbose
                 Write-Message "ffmpeg failed with exit code: $($ffmpegOutput.ExitCode)" -Type Error

--- a/Modules/Media/Public/Export-MediaStream.ps1
+++ b/Modules/Media/Public/Export-MediaStream.ps1
@@ -58,7 +58,7 @@ function Export-MediaStream {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$InputPath,
         [Parameter(Mandatory, Position = 1)]
@@ -74,16 +74,15 @@ function Export-MediaStream {
         [switch]$Force
     )
     process {
-        foreach ($function in @('Get-MediaStreams', 'Invoke-FFMpeg')) {
-            $PSDefaultParameterValues["$function`:Verbose"] = $VerbosePreference
-            $PSDefaultParameterValues["$function`:Debug"] = $DebugPreference
-        }
+        Write-Message 'Export-MediaStream' -Type Verbose
+        Write-Message "InputPath: $InputPath; Index: $Index; Type: $Type" -Type Verbose
         $stream = Get-MediaStream -Name $InputPath -Index $Index -Type $Type
         if ($stream) {
+            Write-Message "Stream found: $($stream.Name)" -Type Verbose
             $stream.Export($OutputPath, $Force)
         }
         else {
-            Write-Error "Stream not found at index $Index for type $Type in file $InputPath"
+            Write-Message "Stream not found at index $Index for type $Type in file $InputPath" -Type Error
         }
         return
     }

--- a/Modules/Media/Public/Get-MediaStream.ps1
+++ b/Modules/Media/Public/Get-MediaStream.ps1
@@ -56,6 +56,8 @@ function Get-MediaStream {
         [Parameter(Mandatory = $false)]
         [StreamType]$Type = [StreamType]::All
     )
+    Write-Message "Get-MediaStream: Name: $Name; Index: $Index; Type: $Type" -Type Verbose
+
     if ($Type -eq [StreamType]::All) {
         $codecFilter = $null
     }
@@ -66,16 +68,16 @@ function Get-MediaStream {
     $quotedName = '"' + $Name + '"'
     $processResult = Invoke-FFProbe '-select_streams', "$codecFilter$Index", '-show_streams', $quotedName
     if ($processResult.ExitCode) {
-        Write-Error "Get-MediaStream: Failed to get media stream. Exit code: $($processResult.ExitCode)"
+        Write-Message "Get-MediaStream: Failed to get media stream. Exit code: $($processResult.ExitCode)" -Type Error
         return $null
     }
     $stream = $processResult.Json.streams[0]
     if (-not $stream) {
-        Write-Verbose "No stream found at index $Index for type $Type in file $Name"
+        Write-Message "No stream found at index $Index for type $Type in file $Name" -Type Verbose
         return $null
     }
     # Create MediaStreamInfo object
     $mediaStream = [MediaStreamInfo]::new($Name, $stream, $Index)
-    Write-Verbose "Retrieved $Type stream at index $Index from $Name (type: $($stream.codec_type))."
+    Write-Message "Retrieved $Type stream at index $Index from $Name (type: $($stream.codec_type))." -Type Verbose
     return $mediaStream
 }

--- a/Modules/Media/Public/Invoke-CaptionExtraction.ps1
+++ b/Modules/Media/Public/Invoke-CaptionExtraction.ps1
@@ -1,16 +1,30 @@
+<#
+    Subtitle Codec → File Extension Mapping
+    | Codec Name | Description | Typical Extension | Extractable with FFmpeg | 
+    subrip: Text-based subtitles; .srt, .vtt
+    webvtt: Web Video Text Tracks; .vtt
+    ass / ssa: Advanced SubStation Alpha; .ass, .ssa
+    hdmv_pgs_subtitle: Blu-ray bitmap subtitles; .sup
+    dvd_subtitle: VOBSUB (DVD bitmap subtitles); .sub + .idx
+    mov_text: MP4 embedded text subtitles; .mp4 container
+    microdvd: Frame-based text subtitles; .sub
+    jacosub: Legacy text format; .jss
+    realtext: RealMedia subtitles; .rt
+#>
+$SubtitleCodecExtensions = @{
+    'subrip'            = '.srt'
+    'webvtt'            = '.vtt'
+    'ass'               = '.ass'
+    'ssa'               = '.ssa'
+    'hdmv_pgs_subtitle' = '.sup'
+    'dvd_subtitle'      = '.sub'
+    'mov_text'          = '.mp4'
+    'microdvd'          = '.sub'
+    'jacosub'           = '.jss'
+    'realtext'          = '.rt'
+}
+
 function Invoke-CaptionExtraction {
-    [CmdletBinding(SupportsShouldProcess)]
-    param(
-        [Parameter(Mandatory, ValueFromPipeline)]
-        [ValidateNotNull()]
-        [string]$File,
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]$Destination,
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]$Format
-    )
     <#
     .SYNOPSIS
         Extracts captions from a collection of video files.
@@ -26,75 +40,98 @@ function Invoke-CaptionExtraction {
     .EXAMPLE
         Invoke-CaptionExtraction -File $file -Destination "C:\Output" -WhatIf
     .OUTPUTS
-        Returns a hashtable with processing statistics.
+        Returns an object with the following properties:
+        - Processed: The number of files that were processed.
+        - Skipped: The number of files that were skipped.
+        - Destination: The directory where extracted caption files were saved.
     #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNull()]
+        [string]$File,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Destination,
+        [Parameter()]
+        [string]$Language = 'eng'
+    )
     begin {
         $processedCount = 0
         $skippedCount = 0
-        Write-Message "Invoke-CaptionExtraction: Invoking caption extraction" -Type Verbose
-        Write-Message "Invoke-CaptionExtraction: Destination: $Destination" -Type Verbose
+
+        # TODO: Consider streaming all files at once to Get-MediaStreamCollection
     }
     process {
-        Write-Message "Invoke-CaptionExtraction: File: $File" -Type Verbose
         try {
-            Write-Message "Invoke-CaptionExtraction: 📝 Processing caption extraction for: $File" -Type Verbose
+            Write-Message "📝 Processing caption extraction for: $File" -Type Processing
+
             # Use Get-MediaStreamCollection for efficient processing
-            $streamCollection = Get-MediaStreamCollection -Paths @($File) -Type Subtitle
+            $streamCollection = Get-MediaStreamCollection -Path $File -Type Subtitle
             if (-not $streamCollection -or $streamCollection.Count -eq 0) {
-                Write-Message "Invoke-CaptionExtraction: ⏭️ Skipping: $($File) - no subtitle streams found" -Type Verbose
+                Write-Message "⏭️ No subtitle streams found in $File. File will be skipped." -Type Warning
                 $skippedCount++
                 return
             }
+
             # Get streams for this file
-            $subtitleStreams = $streamCollection[$File]
+            $subtitleStreams = $streamCollection.get_Values()[0] | Where-Object { $_.Language -eq $Language }
             if (-not $subtitleStreams) {
-                Write-Message "Invoke-CaptionExtraction: ⏭️ Skipping: $($File) - no subtitle streams found" -Type Verbose
+                Write-Message "No subtitle streams found for language: $Language in file: $File" -Type Warning
                 $skippedCount++
-                return
             }
-            Write-Message "Invoke-CaptionExtraction: $($subtitleStreams.Count) subtitle streams found" -Type Debug
-            # Filter for subrip (SRT) captions
-            $srtStreams = $subtitleStreams | Where-Object { $_.CodecName -eq 'subrip' }                
-            Write-Message "$($srtStreams.Count) SRT streams found" -Type Debug
-            if ($srtStreams.Count -eq 0) {
-                Write-Message "Invoke-CaptionExtraction: ⏭️ Skipping: $($File) - no SRT captions found" -Type Verbose
-                $skippedCount++
-                return
+
+            Write-Message "$($subtitleStreams.Count) subtitle streams found" -Type Debug
+
+            $outputStreamsByCodec = @{}
+            foreach ($codec in $SubtitleCodecExtensions.Keys) {
+                $matchingStreams = $subtitleStreams | Where-Object { $_.CodecName -eq $codec }
+                if ($matchingStreams -and ($matchingStreams.Count -gt 0)) {
+                    if ($outputStreamsByCodec.ContainsKey($codec)) {
+                        $outputStreamsByCodec[$codec] += $matchingStreams
+                    }
+                    else {
+                        $outputStreamsByCodec[$codec] = @($matchingStreams)
+                    }
+                }
             }
-            elseif ($srtStreams.Count -gt 1) {
-                Write-Message "Invoke-CaptionExtraction: ⏭️ Skipping: $($File) - multiple SRT captions found. Needs manual processing." -Type Warning
-                $skippedCount++
-                return
+
+            $global:outputStreamsByCodec = $outputStreamsByCodec
+
+            foreach ($codec in $outputStreamsByCodec.Keys) {
+                $streams = $outputStreamsByCodec[$codec]
+                if (-not $streams) {
+                    Write-Message "No $codec streams found" -Type Warning
+                    continue
+                }
+                elseif ($streams.Count -gt 1) {
+                    Write-Message "⏭️ $File`: multiple $codec subtitles found. Only the first will be processed. You can manually process the rest of the streams." -Type Warning
+                    $warningCount++
+                }
+
+                $stream = $streams[0]
+                $baseName = [System.IO.Path]::GetFileNameWithoutExtension($File)
+                $outputPath = Get-Path -Path $Destination, "$baseName$($SubtitleCodecExtensions[$codec])" -PathType Absolute
+                if (Test-Path $outputPath) {
+                    Write-Message "⚠️  Overwriting existing caption file: $outputPath" -Type Info
+                    Remove-Item $outputPath -Force
+                }
+                Write-Message "Extracting caption $($stream.TypeIndex) from $File to $outputPath" -Type Verbose
+                Export-MediaStream -InputPath $File -Type Subtitle -Index $stream.TypeIndex -OutputPath $outputPath
+                Write-Message "✅ Successfully extracted caption to: $outputPath" -Type Verbose
+                $processedCount++
             }
-            # Process SRT stream
-            $stream = $srtStreams[0]
-            $baseName = [System.IO.Path]::GetFileNameWithoutExtension($File)
-            $outputPath = Get-Path -Path $Destination, "$baseName.en.$Format" -PathType Absolute
-            # Check if output file exists and inform user about overwriting
-            if (Test-Path $outputPath) {
-                Write-Message "Invoke-CaptionExtraction: ⚠️  Overwriting existing caption file: $outputPath" -Type Verbose
-            }
-            Write-Message "Invoke-CaptionExtraction: Extracting caption $($stream.TypeIndex) from $File" -Type Verbose
-            # Remove existing file first to ensure clean overwrite
-            if (Test-Path $outputPath) {
-                Remove-Item $outputPath -Force
-            }
-            Export-MediaStream -InputPath $File -Type Subtitle -Index $stream.TypeIndex -OutputPath $outputPath
-            Write-Message "Invoke-CaptionExtraction: ✅ Successfully extracted caption to: $outputPath" -Type Verbose
-            $processedCount++
         }
         catch {
-            throw "Invoke-CaptionExtraction: ❌ Error processing captions for: $File. Error: $($_.Exception.Message)"
+            throw "❌ Error processing captions for: $File. Error: $($_.Exception.Message)"
         }
     }
     end {
-        # Caption extraction summary
-        Write-Message "Invoke-CaptionExtraction: `n📊 === Caption Extraction Summary ===" -Type Verbose
-        Write-Message "Invoke-CaptionExtraction: ✅ Processed: $processedCount" -Type Verbose
-        Write-Message "Invoke-CaptionExtraction: ⏭️ Skipped: $skippedCount" -Type Verbose
-        Write-Message "Invoke-CaptionExtraction :📁 Output directory: $Destination" -Type Verbose
+        Write-Message "📊 Caption extraction complete: ✅ Processed: $processedCount; ❌ Skipped: $skippedCount" -Type Success
+
         return @{
             Processed   = $processedCount
+            Warning     = $warningCount
             Skipped     = $skippedCount
             Destination = $Destination
         }

--- a/Modules/Media/Public/Invoke-ChapterExtraction.ps1
+++ b/Modules/Media/Public/Invoke-ChapterExtraction.ps1
@@ -8,11 +8,11 @@ function Invoke-ChapterExtraction {
         [ValidateNotNullOrEmpty()]
         [string]$ChapterDirectory,
         [Parameter()]
-        [ValidateEpisodeNumberAttribute()]
+        [ValidateRange(1, 1000)]
         [int]$ChapterNumber = 2,
         [Parameter()]
-        [ValidatePositiveNumberAttribute()]
-        [int]$ChapterDuration = 30
+        [ValidateRange(1, 300)]
+        [int]$ChapterDuration = 15
     )
     <#
     .SYNOPSIS
@@ -36,7 +36,7 @@ function Invoke-ChapterExtraction {
         Returns a hashtable with processing statistics.
     #>
     begin {
-        Write-Message "`n🎬 === Chapter Extraction Phase ===" -Type Verbose
+        Write-Message '🎬 Chapter Extraction Phase' -Type Verbose
         $processedCount = 0
         $skippedCount = 0
         # Create clips subdirectory

--- a/Modules/Media/Public/Invoke-VideoCopy.ps1
+++ b/Modules/Media/Public/Invoke-VideoCopy.ps1
@@ -68,22 +68,25 @@ function Invoke-VideoCopy {
         [Parameter(Mandatory)]
         [ValidateNotNull()]
         [object[]]$Episodes,
+        [ValidateRange(1, 1000)]
+        [int]$EpisodeStart = 1,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [ValidateCount(1, [int]::MaxValue)]
-        [ValidateFilePatternAttribute()]
         [string[]]$FilePatterns,
         [Parameter()]
-        [ValidatePositiveNumberAttribute()]
-        [long]$MinimumFileSize = $Script:DefaultMinimumFileSize
+        [ValidateRange(1, [int]::MaxValue)]
+        [long]$MinimumFileSize = 1GB
     )
     begin {
+        Write-Message '🎬 Video Copy phase' -Type Processing
+
         $allPaths = @()
-        Write-Message "Initializing video copy with pipeline support" -Type Verbose
+        Write-Message 'Initializing video copy' -Type Verbose
         Write-Message "Destination: $Destination" -Type Verbose
         Write-Message "Title: $Title" -Type Verbose
         Write-Message "Season: $Season" -Type Verbose
         Write-Message "Episode count: $($Episodes.Count)" -Type Verbose
+        Write-Message "Episode start: $EpisodeStart" -Type Verbose
         Write-Message "File patterns: $($FilePatterns -join ', ')" -Type Verbose
         Write-Message "Minimum file size: $MinimumFileSize" -Type Verbose
     }
@@ -93,8 +96,7 @@ function Invoke-VideoCopy {
         }
     }
     end {
-        return Invoke-WithErrorHandling -OperationName "Video copying" -DefaultReturnValue @() -ErrorEmoji "🎬"  -ScriptBlock {
-            Write-Message '🎬 Video copying phase' -Type Processing
+        return Invoke-WithErrorHandling -OperationName 'Video Copy' -DefaultReturnValue @() -ErrorEmoji '🎬' -ScriptBlock {
             Write-Message "Processing directories: $($allPaths -join ', ')" -Type Verbose
             # Step 1: Get filtered video files using the extracted helper function
             $allAcceptedFiles = Get-FilteredVideoFiles -Path $allPaths -FilePatterns $FilePatterns -MinimumFileSize $MinimumFileSize
@@ -104,8 +106,15 @@ function Invoke-VideoCopy {
                 return @()
             }
             # Step 2: Copy files with metadata using the extracted helper function
-            $copiedFiles = Copy-FileWithMetadata -Files $allAcceptedFiles -Episodes $Episodes -Destination $Destination -Title $Title -Season $Season
+            $copiedFiles = Copy-FileWithMetadata `
+                -Files $allAcceptedFiles `
+                -Episodes $Episodes `
+                -Destination $Destination `
+                -Title $Title `
+                -Season $Season `
+                -EpisodeStart $EpisodeStart
             return $copiedFiles
         }
+        Write-Message 'Invoke-VideoCopy: begin (start)' -Type Processing
     }
-} 
+}

--- a/Modules/Media/Public/MediaStreamInfo.ps1
+++ b/Modules/Media/Public/MediaStreamInfo.ps1
@@ -170,7 +170,7 @@ class MediaStreamInfo {
             }
         }
         # Build ffmpeg arguments using the extracted method
-        $ffmpegArgs = $this.GetFFMpegArgs($OutputPath)
+        $ffmpegArgs = $this.GetFFMpegFullArgs($OutputPath)
         Write-Verbose "FFmpeg command: ffmpeg $($ffmpegArgs -join ' ')"
         $progressActivity = "Exporting $($this.CodecType) Stream $($this.TypeIndex) from $($this.SourceFile)"
         try {

--- a/Modules/Rip/Private/Convert-TypeToBitrate.ps1
+++ b/Modules/Rip/Private/Convert-TypeToBitrate.ps1
@@ -1,3 +1,10 @@
+# Audio bitrates
+$Script:AudioBitrates = @{
+    'Surround 5.1' = 384
+    'Stereo'       = 160
+    'Mono'         = 80
+}
+
 function Convert-TypeToBitrate {
     <#
     .SYNOPSIS

--- a/Modules/Rip/Private/Convert-TypeToMixdown.ps1
+++ b/Modules/Rip/Private/Convert-TypeToMixdown.ps1
@@ -1,3 +1,10 @@
+# Audio mixdowns
+$Script:AudioMixdowns = @{
+    'Surround 5.1' = '5point1'
+    'Stereo'       = 'stereo'
+    'Mono'         = 'mono'
+}
+
 function Convert-TypeToMixdown {
     <#
     .SYNOPSIS
@@ -12,4 +19,4 @@ function Convert-TypeToMixdown {
         return $Script:AudioMixdowns[$Type]
     }
     throw "Unknown audio type: $Type"
-} 
+}

--- a/Modules/Rip/Private/Invoke-CaptionExtractionPhase.ps1
+++ b/Modules/Rip/Private/Invoke-CaptionExtractionPhase.ps1
@@ -15,13 +15,11 @@ function Invoke-CaptionExtractionPhase {
         Array of copied video file paths to process for caption extraction.
     .PARAMETER CaptionDirectory
         Optional custom directory name for captions. Default is 'Captions'.
-    .PARAMETER Formats
-        Array of caption formats to extract. Default is @('srt', 'vtt').
     .EXAMPLE
         $stats = Invoke-CaptionExtractionPhase -SeasonDir "C:\Shows\Breaking Bad\Season 01" -CopiedFiles $videoFiles
         Extracts captions in SRT and VTT formats from all copied video files.
     .EXAMPLE
-        $stats = Invoke-CaptionExtractionPhase -SeasonDir "C:\Shows\The Office\Season 03" -CopiedFiles $videoFiles -CaptionDirectory "Subtitles" -Formats @('srt')
+        $stats = Invoke-CaptionExtractionPhase -SeasonDir "C:\Shows\The Office\Season 03" -CopiedFiles $videoFiles -CaptionDirectory "Subtitles"
         Extracts only SRT captions into a custom "Subtitles" directory.
     .OUTPUTS
         [PSCustomObject] Object containing processing statistics:
@@ -44,31 +42,23 @@ function Invoke-CaptionExtractionPhase {
         [string[]]$CopiedFiles,
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [string]$CaptionDirectory = 'Captions',
-        [Parameter()]
-        [ValidateNotNull()]
-        [string[]]$Formats = @('srt', 'vtt')
+        [string]$CaptionDirectory = 'Captions'
     )
-    return Invoke-WithErrorHandling -OperationName "Caption extraction phase" -DefaultReturnValue @{ Processed = 0; Failed = 0; Total = 0 } -ErrorEmoji "🎬" -ScriptBlock {
-        Write-Message "🎬 Starting caption extraction phase" -Type Processing
+    return Invoke-WithErrorHandling -OperationName 'Caption extraction phase' -DefaultReturnValue @{ Processed = 0; Failed = 0; Total = 0 } -ErrorEmoji "🎬" -ScriptBlock {
+        Write-Message '🎬 Starting caption extraction phase' -Type Verbose
         Write-Message "Caption formats: $($Formats -join ', ')" -Type Verbose
         Write-Message "Files to process: $($CopiedFiles.Count)" -Type Verbose
         # Create caption directory
-        $captionDir = New-ProcessingDirectory -Path (Get-Path -Path $SeasonDir, $CaptionDirectory -PathType Absolute) -Description "caption"
-        # Define the caption extraction command for multiple formats
-        $cmd = {
-            $results = @()
-            foreach ($format in $Formats) {
-                $results += ($CopiedFiles | Invoke-CaptionExtraction -Destination $captionDir -Format $format)
-            }
-            return $results
-        }
+        $captionDir = New-ProcessingDirectory -Path (Get-Path -Path $SeasonDir, $CaptionDirectory -PathType Absolute) -Description 'caption'
+
+        $cmd = { return $CopiedFiles | Invoke-CaptionExtraction -Destination $captionDir }
+
         # Execute caption extraction using the centralized export function
         $captionStats = Export-VideoItem -Path $SeasonDir -Destination $captionDir -CopiedFiles $CopiedFiles -Command $cmd -ItemType Caption
         if ($captionStats.Processed -gt 0) {
-            Write-Message "🎬 Captions extracted: $($captionStats.Processed)" -Type Processing
+            Write-Message "🎬 Captions extracted: $($captionStats.Processed)" -Type Success
         } else {
-            Write-Message "⚠️ No captions were extracted" -Type Warning
+            Write-Message '⚠️ No captions were extracted' -Type Warning
         }
         return $captionStats
     }

--- a/Modules/Rip/Private/Invoke-ChapterExtractionPhase.ps1
+++ b/Modules/Rip/Private/Invoke-ChapterExtractionPhase.ps1
@@ -45,21 +45,26 @@ function Invoke-ChapterExtractionPhase {
         [string[]]$CopiedFiles,
         [Parameter()]
         [ValidateRange(1, 99)]
-        [int]$ChapterNumber = $Script:DefaultChapterNumber,
+        [int]$ChapterNumber = 3,
         [Parameter()]
         [ValidateRange(1, 300)]
-        [int]$ChapterDuration = $Script:DefaultChapterDuration,
+        [int]$ChapterDuration = 15,
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$ChapterDirectory = 'Chapters'
     )
-    return Invoke-WithErrorHandling -OperationName "Chapter extraction phase" -DefaultReturnValue @{ Processed = 0; Failed = 0; Total = 0 } -ErrorEmoji "🎬" -ScriptBlock {
-        Write-Message "🎬 Starting chapter extraction phase" -Type Processing
+    return Invoke-WithErrorHandling `
+        -OperationName 'Chapter extraction phase' `
+        -DefaultReturnValue @{ Processed = 0; Failed = 0; Total = 0 } `
+        -ErrorEmoji '🎬' `
+        -ScriptBlock {
+
+        Write-Message '🎬 Starting chapter extraction phase' -Type Verbose
         Write-Message "Chapter number: $ChapterNumber" -Type Verbose
         Write-Message "Chapter duration: $ChapterDuration seconds" -Type Verbose
         Write-Message "Files to process: $($CopiedFiles.Count)" -Type Verbose
         # Create chapter directory
-        $chapterDir = New-ProcessingDirectory -Path (Get-Path -Path $SeasonDir, $ChapterDirectory -PathType Absolute) -Description "chapter"
+        $chapterDir = New-ProcessingDirectory -Path (Get-Path -Path $SeasonDir, $ChapterDirectory -PathType Absolute) -Description 'chapter'
         # Define the chapter extraction command
         $cmd = {
             return $CopiedFiles | Invoke-ChapterExtraction -ChapterNumber $ChapterNumber -ChapterDuration $ChapterDuration -ChapterDirectory $chapterDir
@@ -68,9 +73,10 @@ function Invoke-ChapterExtractionPhase {
         $chapterStats = Export-VideoItem -Path $SeasonDir -Destination $chapterDir -CopiedFiles $CopiedFiles -Command $cmd -ItemType Chapter
         if ($chapterStats.Processed -gt 0) {
             Write-Message "🎬 Chapters extracted: $($chapterStats.Processed)" -Type Processing
-        } else {
-            Write-Message "⚠️ No chapters were extracted" -Type Warning
+        }
+        else {
+            Write-Message '⚠️ No chapters were extracted' -Type Warning
         }
         return $chapterStats
     }
-} 
+}

--- a/Modules/Rip/Private/New-ProcessingDirectoryStructure.ps1
+++ b/Modules/Rip/Private/New-ProcessingDirectoryStructure.ps1
@@ -45,7 +45,7 @@ function New-ProcessingDirectoryStructure {
         [int]$Season,
         [Parameter()]
         [ValidateNotNull()]
-        [string[]]$SubDirectories = $Script:ProcessingSubDirectories,
+        [string[]]$SubDirectories = @('HandBrake', 'Remux', 'Topaz', 'Bonus'),
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$BasePath = '.'

--- a/Modules/Rip/Public/Convert-VideoFiles.ps1
+++ b/Modules/Rip/Public/Convert-VideoFiles.ps1
@@ -70,7 +70,7 @@ function Convert-VideoFiles {
                     $extraArgs += "--preset-import-file `"$PresetFile`""
                 }
                 $fullArgs = @($HandbrakeOptions + $extraArgs)
-                $handbrakeExe = $Script:HandBrakeCLIPath
+                $handbrakeExe = 'C:\Program Files\HandBrake\HandBrakeCLI.exe'
                 Write-Message "Convert-VideoFiles: $filePrefix`: HandBrake command: $handbrakeExe $($fullArgs -join ' ')" -Type Verbose
                 # Use Invoke-Process to call HandBrakeCLI
                 Write-Message '** Using Invoke-Process to call HandBrakeCLI with argument array' -Type Debug

--- a/Modules/Rip/Public/Invoke-DvdProcessing.ps1
+++ b/Modules/Rip/Public/Invoke-DvdProcessing.ps1
@@ -158,18 +158,20 @@ function Invoke-DvdProcessing {
         [ValidateNotNullOrEmpty()]
         [string[]]$FilePatterns,
         [Parameter(Mandatory)]
-        [ValidateSeasonNumberAttribute()]
+        [ValidateRange(1, 1000)]
         [int]$Season,
+        [Parameter()]
+        [int]$EpisodeStart = 1,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$TvDbSeriesUrl,
         [Parameter()]
-        [switch[]]$SkipChapterExtraction,
+        [switch]$SkipChapterExtraction,
         [Parameter()]
-        [switch[]]$SkipCaptionExtraction
+        [switch]$SkipCaptionExtraction
     )
     begin {
-        Write-Message '🚀 Starting $Title processing' -Type Processing
+        Write-Message "🚀 Starting $Title processing" -Type Processing
         Write-Message 'Starting DVD processing workflow' -Type Verbose
         Write-Message "Title: $Title" -Type Verbose
         Write-Message "Directories: $Path" -Type Verbose
@@ -178,18 +180,26 @@ function Invoke-DvdProcessing {
         Write-Message "TVDb URL: $TvDbSeriesUrl" -Type Verbose
     }
     process {
-        Invoke-WithErrorHandling -OperationName "DVD processing" -DefaultReturnValue @() -ErrorEmoji "🎬" -ScriptBlock {
+        Invoke-WithErrorHandling -OperationName 'DVD processing' -DefaultReturnValue @() -ErrorEmoji '🎬' -ScriptBlock {
             # Step 1: Create directory structure using the extracted helper function
             $dirStructure = New-ProcessingDirectoryStructure -Title $Title -Season $Season
             $seasonDir = $dirStructure.SeasonDir
             # Step 2: Retrieve TVDb episode information using the season scan function
-            $episodeInfo = Invoke-SeasonScan -Season $Season -TvDbSeriesUrl $TvDbSeriesUrl            
-            if ($episodeInfo.Count -eq 0) {
+            $episodes = Invoke-SeasonScan -Season $Season -TvDbSeriesUrl $TvDbSeriesUrl
+            if ($episodes.Count -eq 0) {
                 Write-Message '🚫 Season scanning failed. Cannot proceed without episode information.' -Type Error
                 return
             }
             # Step 3: Copy video files using the centralized video copy function
-            $copiedFiles = Invoke-VideoCopy -Path $Path -Destination $seasonDir -Title $Title -Season $Season -EpisodeInfo $episodeInfo -FilePatterns $FilePatterns
+            $copiedFiles = Invoke-VideoCopy `
+                -Path $Path `
+                -Destination $seasonDir `
+                -Title $Title `
+                -Season $Season `
+                -Episodes $episodes `
+                -FilePatterns $FilePatterns `
+                -EpisodeStart $EpisodeStart
+
             if ($copiedFiles.Count -eq 0) {
                 Write-Message '🚫 Video copying failed. Cannot proceed without copied files.' -Type Error
                 return

--- a/Modules/Rip/Public/Invoke-SeasonScan.ps1
+++ b/Modules/Rip/Public/Invoke-SeasonScan.ps1
@@ -35,7 +35,7 @@ function Invoke-SeasonScan {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSeasonNumberAttribute()]
+        [ValidateRange(1, 1000)]
         [int]$Season,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/Modules/Rip/RipTools.psm1
+++ b/Modules/Rip/RipTools.psm1
@@ -84,4 +84,4 @@ foreach ($function in $SharedFunctions) {
     }
 }
 
-Export-ModuleMember -Function $PublicFunctions 
+Export-ModuleMember -Function $PublicFunctions


### PR DESCRIPTION
# Add support for episode start in `Invoke-DvdProcessing`

And along the way:
- More strings are single-quoted (randomly whenever I saw the linter error)
- Remove usage of validation classes that don't exist (ex. `ValidateFilePatternAttribute`, `ValidatePositiveNumberAttribute`)
- Use `Get-Item` instead of `Get-ChildItem`. If there is just one directory passed to `Get-ChildItem`, it returns the files in that directory. If there are multiple directories (like with a wildcard) then it returns the list of directories themselves.
- Cleaned up noisy output from ffmpeg processing
- Removed stale usage of Setting $PSDefaultParameterValues for specific functions. Need to have a better way of making sure $VerbosePreference and $DebugPreference are passed along.
- Additional verbose/info strings
- More usage of `Write-Message` instead of `Write-Warning`, `Write-Verbose`, etc.
- Add support in caption extraction to extract all known subtitle codecs
- Simplified `Invoke-CaptionExtractionPhase`
- Remove old constants such as `$Script:ProcessingSubDirectories` or `$Script:HandbrakeCLIPath`
- No idea why `-SkipChapterExtraction` and `-SwitchCaptionExtraction` were `[switch[]]` instead of just `[switch]`. Fixed now.
