### PR TITLE
Fix Invoke-HandbrakeConversion

### DIFF
--- a/Modules/Media/Public/Export-AudioStream.ps1
+++ b/Modules/Media/Public/Export-AudioStream.ps1
@@ -93,7 +93,7 @@ function Export-AudioStream {
             # Convert to MediaStreamInfoCollection
             $streamCollection = ConvertTo-MediaStreamCollection -Streams $audioStreams
             # Export using the collection function
-            $exportResults = Export-MediaStreamCollection -StreamCollection $streamCollection -Type Audio -Language $Language -OutputDirectory $OutputDirectory -OutputFormat $OutputFormat -Force:$Force
+            $exportResults = Export-MediaStreamCollection -StreamCollection $streamCollection -Type Audio -OutputDirectory $OutputDirectory -OutputFormat $OutputFormat -Force:$Force
             # Process results
             foreach ($result in $exportResults) {
                 if ($result.Success) {

--- a/Modules/Media/Public/Export-SubtitleStream.ps1
+++ b/Modules/Media/Public/Export-SubtitleStream.ps1
@@ -93,7 +93,7 @@ function Export-SubtitleStream {
             # Convert to MediaStreamInfoCollection
             $streamCollection = ConvertTo-MediaStreamCollection -Streams $subtitleStreams
             # Export using the collection function
-            $exportResults = Export-MediaStreamCollection -StreamCollection $streamCollection -Type Subtitle -Language $Language -OutputDirectory $OutputDirectory -OutputFormat $OutputFormat -Force:$Force
+            $exportResults = Export-MediaStreamCollection -StreamCollection $streamCollection -Type Subtitle -OutputDirectory $OutputDirectory -OutputFormat $OutputFormat -Force:$Force
             # Process results
             foreach ($result in $exportResults) {
                 if ($result.Success) {

--- a/Modules/Media/Public/Get-AudioData.ps1
+++ b/Modules/Media/Public/Get-AudioData.ps1
@@ -44,7 +44,7 @@ function Get-AudioData {
         # Use Get-MediaStreamCollection for efficient processing
         $videoPaths = $videos | Select-Object -ExpandProperty FullName
         Write-Message "Processing $($videoPaths.Count) files using Get-MediaStreamCollection" -Type Verbose
-        $streamCollection = Get-MediaStreamCollection -Paths $videoPaths -Type Audio
+        $streamCollection = $videoPaths | Get-MediaStreamCollection -Type Audio
         if (-not $streamCollection -or $streamCollection.Count -eq 0) {
             Write-Message "No audio streams found in any files" -Type Verbose
             return @()

--- a/Modules/Media/Public/Get-AudioStream.ps1
+++ b/Modules/Media/Public/Get-AudioStream.ps1
@@ -69,7 +69,7 @@ function Get-AudioStream {
         try {
             Write-Message "Processing $($allFiles.Count) files using Get-MediaStreamCollection" -Type Verbose
             # Use Get-MediaStreamCollection for efficient processing
-            $streamCollection = Get-MediaStreamCollection -Paths $allFiles -Type Audio -Language $Language
+            $streamCollection = $allFiles | Get-MediaStreamCollection -Type Audio
             if (-not $streamCollection -or $streamCollection.Count -eq 0) {
                 Write-Message "No audio streams found in any files" -Type Verbose
                 return @()

--- a/Modules/Media/Public/Get-MultipleAudioStreams.ps1
+++ b/Modules/Media/Public/Get-MultipleAudioStreams.ps1
@@ -31,8 +31,6 @@ function Get-MultipleAudioStreams {
         [ValidateNotNullOrEmpty()]
         [string]$File,
         [Parameter()]
-        [string]$Language = 'eng',
-        [Parameter()]
         [switch]$WriteHost
     )
     begin {
@@ -57,7 +55,7 @@ function Get-MultipleAudioStreams {
         Write-Message "Processing $($allFiles.Count) files for multiple audio streams" -Type Verbose
         try {
             # Use Get-MediaStreamCollection for efficient processing
-            $streamCollection = Get-MediaStreamCollection -Paths $allFiles -Type Audio -Language $Language
+            $streamCollection = $allFiles | Get-MediaStreamCollection -Type Audio
             if (-not $streamCollection -or $streamCollection.Count -eq 0) {
                 Write-Message "No audio streams found in any files" -Type Verbose
                 return @{}

--- a/Modules/Media/Public/Get-SubtitleStream.ps1
+++ b/Modules/Media/Public/Get-SubtitleStream.ps1
@@ -32,8 +32,6 @@ function Get-SubtitleStream {
         [ValidateNotNullOrEmpty()]
         [string[]]$Source,
         [Parameter()]
-        [string]$Language = 'eng',
-        [Parameter()]
         [string]$CodecName
     )
     begin {
@@ -69,7 +67,7 @@ function Get-SubtitleStream {
         try {
             Write-Message "Processing $($allFiles.Count) files using Get-MediaStreamCollection" -Type Verbose
             # Use Get-MediaStreamCollection for efficient processing
-            $streamCollection = Get-MediaStreamCollection -Paths $allFiles -Type Subtitle -Language $Language
+            $streamCollection = $allFiles | Get-MediaStreamCollection -Type Subtitle
             if (-not $streamCollection -or $streamCollection.Count -eq 0) {
                 Write-Message "No subtitle streams found in any files" -Type Verbose
                 return @()

--- a/Modules/Media/Public/Invoke-SafeFileRename.ps1
+++ b/Modules/Media/Public/Invoke-SafeFileRename.ps1
@@ -43,7 +43,6 @@ function Invoke-SafeFileRename {
         [hashtable]$FileMappings
     )
     begin {
-        Set-DefaultParameters
         Write-Message 'Initializing SafeFileRename for multiple directories' -Type Verbose
         Write-Message "File mappings: $($FileMappings | ConvertTo-Json -Compress)" -Type Verbose
         $processedDirectories = 0

--- a/Modules/Media/Public/Show-MultipleAudioStreams.ps1
+++ b/Modules/Media/Public/Show-MultipleAudioStreams.ps1
@@ -29,8 +29,6 @@ function Show-MultipleAudioStreams {
         [ValidateNotNullOrEmpty()]
         [string]$File,
         [Parameter()]
-        [string]$Language = 'eng',
-        [Parameter()]
         [switch]$ShowStreams
     )
     begin {
@@ -54,7 +52,7 @@ function Show-MultipleAudioStreams {
             }
             Write-Message "Processing $($allFiles.Count) files for multiple audio streams" -Type Verbose
             # Use Get-MediaStreamCollection for efficient processing
-            $streamCollection = Get-MediaStreamCollection -Paths $allFiles -Type Audio -Language $Language
+            $streamCollection = $allFiles |Get-MediaStreamCollection -Type Audio
             if (-not $streamCollection -or $streamCollection.Count -eq 0) {
                 Write-Message "No audio streams found in any files" -Type Verbose
                 return

--- a/Modules/Rip/Private/Get-FilteredAudioStreams.ps1
+++ b/Modules/Rip/Private/Get-FilteredAudioStreams.ps1
@@ -38,13 +38,7 @@ function Get-FilteredAudioStreams {
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$Path,
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]$Language = 'eng',
-        [Parameter()]
-        [ValidateRange(1, 10)]
-        [int]$Count = 1
+        [string]$Path
     )
     $skippedFiles = @()
     $result = @{}
@@ -57,9 +51,9 @@ function Get-FilteredAudioStreams {
     Write-Message "Processing $($mkvFiles.Count) MKV files using Get-MediaStreamCollection" -Type Verbose
     # Use Get-MediaStreamCollection for efficient processing
     $filePaths = $mkvFiles | Select-Object -ExpandProperty FullName
-    $streamCollection = Get-MediaStreamCollection -Paths $filePaths -Type Audio -Language $Language
+    $streamCollection = $filePaths | Get-MediaStreamCollection -Type Audio
     if (-not $streamCollection -or $streamCollection.Count -eq 0) {
-        Write-Message "No audio streams found in any files" -Type Verbose
+        Write-Message 'No audio streams found in any files' -Type Verbose
         return $result
     }
     foreach ($fileEntry in $streamCollection.GetEnumerator()) {

--- a/Modules/Rip/Public/Invoke-BonusContentProcessing.ps1
+++ b/Modules/Rip/Public/Invoke-BonusContentProcessing.ps1
@@ -34,9 +34,6 @@ function Invoke-BonusContentProcessing {
         [ValidateNotNullOrEmpty()]
         [string]$Destination,
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]$Language = 'eng',
-        [Parameter()]
         [switch]$Force
     )
     begin {
@@ -57,7 +54,7 @@ function Invoke-BonusContentProcessing {
         $outputDirFull = Get-Path -Path $Destination -PathType Absolute -Create Directory
         Write-Message "Processing $originalDirFull for $Language audio streams" -Type Verbose
         # Get filtered audio streams using the centralized function
-        $streamResult = Get-FilteredAudioStreams -Path $originalDirFull -Language $Language -Count 1
+        $streamResult = Get-FilteredAudioStreams -Path $originalDirFull
         if ($streamResult.Count -eq 0) {
             Write-Message 'No streams found' -Type Warning
             return

--- a/Modules/Rip/Public/Invoke-HandbrakeConversion.ps1
+++ b/Modules/Rip/Public/Invoke-HandbrakeConversion.ps1
@@ -47,7 +47,7 @@ function Invoke-HandbrakeConversion {
         $Destination = New-ProcessingDirectory -Path $Destination -Description 'HandBrake output' -SuppressOutput
         Write-Message "Invoke-HandbrakeConversion: Processing $Path for $Language audio streams" -Type Verbose
         # Get filtered audio streams using the centralized function
-        $allStreams = Get-FilteredAudioStreams -Path $Path -Language $Language -Count 10
+        $allStreams = Get-FilteredAudioStreams -Path $Path
         Write-Message "Invoke-HandbrakeConversion: Files ($($allStreams.Count)): $($allStreams.Keys -join ', ')" -Type Verbose
         # Use centralized temp directory management
         Use-TempDirectory -ScriptBlock {

--- a/Modules/Rip/README.md
+++ b/Modules/Rip/README.md
@@ -157,9 +157,9 @@ Invoke-BonusContentProcessing -DriveLetter "D:" -OutputPath "C:\Bonus\Movie" -Fe
 - [RIP VIDEO FILES](#rip-video-files)
 - [PROCESS RIPPED VIDEO FILES](#process-ripped-video-files)
 - [VERIFY AND RENAME](#verify-and-rename)
-- [HANDBRAKE](#handbrake)
-- [REMUX](#remux)
-- [TOPAZ](#topaz)
+- [HANDBRAKE](#handbrake) - only for files being upscaled
+- [REMUX](#remux) - only for files being upscaled
+- [TOPAZ](#topaz) - only for files being upscaled
 - [BONUS](#bonus)
 - [PLEX](#plex)
 


### PR DESCRIPTION
# Fix Invoke-HandbrakeConversion
- Remove `-Language` argument throughout (this is a future TODO to bring  Language back)
- Update RipTools readme