### PR TITLE
Write-Message: Always log to file

### DIFF
--- a/Modules/Shared/Public/Write-Message.ps1
+++ b/Modules/Shared/Public/Write-Message.ps1
@@ -296,6 +296,11 @@ function Write-Message {
         }
     }
     process {
+        # Log to file first
+        if ($effectiveLogFile) {
+            Add-Content -Path $effectiveLogFile -Value $text
+        }
+
         # Route to appropriate PowerShell stream based on type
         switch ($Type) {
             'Debug' {
@@ -371,9 +376,6 @@ function Write-Message {
                     else {
                         Write-Host -Object $text -ForegroundColor $effectiveColor
                     }
-                }
-                if ($effectiveLogFile) {
-                    Add-Content -Path $effectiveLogFile -Value $text
                 }
             }
         }


### PR DESCRIPTION
# `Write-Message`
When logging to file, only some types were being written to a file. Others (Error, Warning, etc.) were not in the log file. Now, log to file first so it always gets done.